### PR TITLE
Make tag names consistent

### DIFF
--- a/reference/UiTPAS.v2.json
+++ b/reference/UiTPAS.v2.json
@@ -27,7 +27,7 @@
       "name": "Events"
     },
     {
-      "name": "FinancialReports"
+      "name": "Financial reports"
     },
     {
       "name": "Organizers"
@@ -1025,7 +1025,7 @@
       "get": {
         "summary": "Get suggested financial report periods",
         "tags": [
-          "FinancialReports"
+          "Financial reports"
         ],
         "responses": {
           "200": {
@@ -1135,7 +1135,7 @@
           }
         },
         "tags": [
-          "FinancialReports"
+          "Financial reports"
         ],
         "description": "Starts a financial report export. The result of this request is a `reportId` that can be used to request the status of the report export and the download.\n\nThe caller of this request must have `ORGANIZER_REPORTS` permission for the given organizer.\n",
         "security": [
@@ -1233,7 +1233,7 @@
           }
         ],
         "tags": [
-          "FinancialReports"
+          "Financial reports"
         ]
       }
     },
@@ -1259,7 +1259,7 @@
       "get": {
         "summary": "Get financial report status",
         "tags": [
-          "FinancialReports"
+          "Financial reports"
         ],
         "responses": {
           "200": {
@@ -1380,7 +1380,7 @@
         "operationId": "get-financials-organizers-reports-download",
         "description": "Retrieve the actual report zip file of an `available` report.\n\nThe caller of this request must have `ORGANIZER_REPORTS` permission for the given organizer.\n",
         "tags": [
-          "FinancialReports"
+          "Financial reports"
         ],
         "security": [
           {

--- a/reference/UiTPAS.v2.json
+++ b/reference/UiTPAS.v2.json
@@ -36,7 +36,7 @@
       "name": "Passholders"
     },
     {
-      "name": "TicketSales"
+      "name": "Ticket sales"
     },
     {
       "name": "Schools"
@@ -48,7 +48,7 @@
       "get": {
         "summary": "Get tariffs",
         "tags": [
-          "TicketSales"
+          "Ticket sales"
         ],
         "responses": {
           "200": {
@@ -171,7 +171,7 @@
       "post": {
         "summary": "Register ticket sale(s)",
         "tags": [
-          "TicketSales"
+          "Ticket sales"
         ],
         "operationId": "post-ticket-sales",
         "responses": {
@@ -360,7 +360,7 @@
         },
         "description": "Cancels a single ticket sale registration by its id. (Returned in the response of the ticket sale registration request.)",
         "tags": [
-          "TicketSales"
+          "Ticket sales"
         ],
         "security": [
           {


### PR DESCRIPTION
### Changed

- Renamed API operation tags that used `CamelCase` to use normal human-readable names, so they are consistent with other tags

---

Before:
![Screen Shot 2021-05-27 at 15 38 50](https://user-images.githubusercontent.com/959026/119836001-a6d85500-bf01-11eb-8816-a77667bec51d.png)

After:
![Screen Shot 2021-05-27 at 15 38 42](https://user-images.githubusercontent.com/959026/119836028-ac359f80-bf01-11eb-97a9-d8fefb2da58c.png)