### PR TITLE
Add config to make it easier to get a PR ready for review

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -1,0 +1,7 @@
+# CODEOWNERS are automatically assigned as possible reviewers to new PRs.
+
+# Global owners (also need to be duplicated in later rules)
+* @erwin1 @bertramakers
+
+# Owners of the markdown docs
+/docs/ @erwin1 @bertramakers @JurgenG @brusselsregular

--- a/.github/pull_request_template.md
+++ b/.github/pull_request_template.md
@@ -1,0 +1,15 @@
+### Added
+
+- [Added ...]
+
+### Changed
+
+- [Changed ...]
+
+### Removed
+
+- [Removed ...]
+
+### Fixed
+
+- [Fixed ...]


### PR DESCRIPTION
### Added

- Added template for PR descriptions
- Added list of code-owners that automatically get assigned as reviewers depending on the changed files

---

With this config, Erwin and me will automatically get assigned as reviewers to any PR, and Jean-Marie and Jurgen will also be assigned if the PR makes changes to markdown files in the docs directory. (Only 1 reviewer needs to approve though)