### PR TITLE
Small OpenAPI file optimizations

### DIFF
--- a/reference/UiTPAS.v2.json
+++ b/reference/UiTPAS.v2.json
@@ -1,7 +1,7 @@
 {
   "openapi": "3.0.0",
   "info": {
-    "title": "UiTPAS API Reference",
+    "title": "UiTPAS API",
     "version": "2.0",
     "contact": {
       "name": "publiq helpdesk",

--- a/reference/UiTPAS.v2.json
+++ b/reference/UiTPAS.v2.json
@@ -2517,9 +2517,7 @@
             "authorizationUrl": "",
             "tokenUrl": "",
             "refreshUrl": "",
-            "scopes": {
-              "https://api.publiq.be/auth/uitpas": "Grants access to the UiTPAS API"
-            }
+            "scopes": {}
           }
         },
         "description": "See [Authentication docs](https://publiq.stoplight.io/docs/authentication/docs/user-access-token.md)"
@@ -2530,9 +2528,7 @@
           "clientCredentials": {
             "tokenUrl": "",
             "refreshUrl": "",
-            "scopes": {
-              "https://api.publiq.be/auth/uitpas": "Grants access to the UiTPAS API"
-            }
+            "scopes": {}
           }
         },
         "description": "See [Authentication docs](https://publiq.stoplight.io/docs/authentication/docs/client-access-token.md)"

--- a/reference/UiTPAS.v2.json
+++ b/reference/UiTPAS.v2.json
@@ -2520,7 +2520,7 @@
             "scopes": {}
           }
         },
-        "description": "See [Authentication docs](https://publiq.stoplight.io/docs/authentication/docs/user-access-token.md)"
+        "description": "A user access token, obtained by redirecting the end user to publiq's authorization server to login. See the [authentication docs about user access tokens](https://publiq.stoplight.io/docs/authentication/docs/user-access-token.md) for more info."
       },
       "CLIENT_ACCESS_TOKEN": {
         "type": "oauth2",
@@ -2531,7 +2531,7 @@
             "scopes": {}
           }
         },
-        "description": "See [Authentication docs](https://publiq.stoplight.io/docs/authentication/docs/client-access-token.md)"
+        "description": "A client access token, obtained by exchanging your client id and client secret for a token via an HTTP request to publiq's authorization server. See the [authentication docs about client access tokens](https://publiq.stoplight.io/docs/authentication/docs/client-access-token.md) for more info."
       }
     },
     "parameters": {},

--- a/reference/UiTPAS.v2.json
+++ b/reference/UiTPAS.v2.json
@@ -2514,8 +2514,8 @@
         "type": "oauth2",
         "flows": {
           "authorizationCode": {
-            "authorizationUrl": "",
-            "tokenUrl": "",
+            "authorizationUrl": "See authentication docs",
+            "tokenUrl": "See authentication docs",
             "refreshUrl": "",
             "scopes": {}
           }
@@ -2526,7 +2526,7 @@
         "type": "oauth2",
         "flows": {
           "clientCredentials": {
-            "tokenUrl": "",
+            "tokenUrl": "See authentication docs",
             "refreshUrl": "",
             "scopes": {}
           }


### PR DESCRIPTION
### Changed

- Changed API name in OpenAPI file. This is a bit more consistent with the UiTdatabank OpenAPI name, for things like Postman imports.
- Added some more info to the description of OAuth2 token types. On endpoints that only support 1 token type, like `GET /passholders/me`, the token name is not shown. So it's best to also mention the token name in the description for clarity. I will make the same changes in the UDB OpenAPI file.

### Removed

- Obsolete OAuth2 scopes from security info.

---

Before:

![Screen Shot 2022-01-14 at 11 52 37](https://user-images.githubusercontent.com/959026/149504032-33863a1e-4821-4aed-acb6-58c6d6bba050.png)

After:

![Screen Shot 2022-01-14 at 11 52 14](https://user-images.githubusercontent.com/959026/149504045-af46deae-d011-4f0e-86fa-adda40ead474.png)





