### PR TITLE
Small OpenAPI file optimizations

### DIFF
--- a/reference/UiTPAS.v2.json
+++ b/reference/UiTPAS.v2.json
@@ -1,7 +1,7 @@
 {
   "openapi": "3.0.0",
   "info": {
-    "title": "UiTPAS API Reference",
+    "title": "UiTPAS API",
     "version": "2.0",
     "contact": {
       "name": "publiq helpdesk",

--- a/reference/UiTPAS.v2.json
+++ b/reference/UiTPAS.v2.json
@@ -2517,9 +2517,7 @@
             "authorizationUrl": "",
             "tokenUrl": "",
             "refreshUrl": "",
-            "scopes": {
-              "https://api.publiq.be/auth/uitpas": "Grants access to the UiTPAS API"
-            }
+            "scopes": {}
           }
         },
         "description": "See [Authentication docs](https://publiq.stoplight.io/docs/authentication/docs/user-access-token.md)"
@@ -2530,9 +2528,7 @@
           "clientCredentials": {
             "tokenUrl": "",
             "refreshUrl": "",
-            "scopes": {
-              "https://api.publiq.be/auth/uitpas": "Grants access to the UiTPAS API"
-            }
+            "scopes": {}
           }
         },
         "description": "See [Authentication docs](https://publiq.stoplight.io/docs/authentication/docs/client-access-token.md)"

--- a/reference/UiTPAS.v2.json
+++ b/reference/UiTPAS.v2.json
@@ -2520,7 +2520,7 @@
             "scopes": {}
           }
         },
-        "description": "See [Authentication docs](https://publiq.stoplight.io/docs/authentication/docs/user-access-token.md)"
+        "description": "A user access token, obtained by redirecting the end user to publiq's authorization server to login. See the [authentication docs about user access tokens](https://publiq.stoplight.io/docs/authentication/docs/user-access-token.md) for more info."
       },
       "CLIENT_ACCESS_TOKEN": {
         "type": "oauth2",
@@ -2531,7 +2531,7 @@
             "scopes": {}
           }
         },
-        "description": "See [Authentication docs](https://publiq.stoplight.io/docs/authentication/docs/client-access-token.md)"
+        "description": "A client access token, obtained by exchanging your client id and client secret for a token via an HTTP request to publiq's authorization server. See the [authentication docs about client access tokens](https://publiq.stoplight.io/docs/authentication/docs/client-access-token.md) for more info."
       }
     },
     "parameters": {},


### PR DESCRIPTION
### Removed

- Removed "Reference" from API name in OpenAPI file. (OpenAPI files are always a reference so it's redundant and not part of the API name, and this is more consistent with the UDB API names which makes it more consistent in for example Postman imports where you see them next to each other.)
- Obsolete OAuth2 scopes

### Changed

- Changed OAuth2 token descriptions to include their name, because on endpoints like `GET /passholders/me` that only support 1 token type, the token name is not shown by Stoplight. So repeating the token name in the description is useful for clarity.

---

Before:

![Screen Shot 2022-01-14 at 11 52 37](https://user-images.githubusercontent.com/959026/149505188-b55c9b21-9203-4208-bb2d-b6c7b8d9023a.png)

After:

![Screen Shot 2022-01-14 at 11 59 09](https://user-images.githubusercontent.com/959026/149505214-c558881f-e1a2-4dda-8af8-1c63e389bdf5.png)



