### PR TITLE
Change UiTPAS API version to 4.0

### DIFF
--- a/reference/uitpas.json
+++ b/reference/uitpas.json
@@ -2,12 +2,12 @@
   "openapi": "3.0.0",
   "info": {
     "title": "UiTPAS API",
-    "version": "2.0",
+    "version": "4.0",
     "contact": {
       "name": "publiq helpdesk",
       "email": "vragen@publiq.be"
     },
-    "description": "With UiTPAS API 2.0 you can retrieve ticket sale prices for specific UiTPAS numbers, and register ticket sales for specific UiTPAS numbers.\n\nFuture versions will also include support for more features like saving points and exchanging them for benefits.\n\n## Postman\n\n<!-- focus: false -->\n\n[![Download postman collection](https://postman.publiq.be/postman-download.svg)](https://postman.publiq.be/?api=uitpas-api)\n\nDo you already have a **client id** and **client secret**?\nDownload a personalized Postman collection to start making requests in seconds!"
+    "description": "With UiTPAS API 4.0 you can retrieve ticket sale prices for specific UiTPAS numbers, and register ticket sales for specific UiTPAS numbers.\n\nFuture versions will also include support for more features like saving points and exchanging them for benefits.\n\n## Postman\n\n<!-- focus: false -->\n\n[![Download postman collection](https://postman.publiq.be/postman-download.svg)](https://postman.publiq.be/?api=uitpas-api)\n\nDo you already have a **client id** and **client secret**?\nDownload a personalized Postman collection to start making requests in seconds!"
   },
   "servers": [
     {

--- a/toc.json
+++ b/toc.json
@@ -56,7 +56,7 @@
     {
       "type": "item",
       "title": "UiTPAS API",
-      "uri": "reference/UiTPAS.v2.json"
+      "uri": "reference/uitpas.json"
     }
   ]
 }


### PR DESCRIPTION
### Changed

- The version number of the UiTPAS API inside the OpenAPI file to 4.0.

### Removed

-  The version number is also removed from the OpenAPI file name because 1) it was incorrect and 2) if we ever do a new major version, we should probably keep the 4.x version on a separate branch and add a new default branch for 5.0. (Which can then be switched between using the branch menu in Stoplight.) Otherwise guides etc will also need to be versioned by file.
